### PR TITLE
Add live camera object detection using YOLO11n model

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.CAMERA" />
     <application
         android:label="cellsay"
         android:name="${applicationName}"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -22,10 +22,12 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
-	<key>LSRequiresIPhoneOS</key>
-	<true/>
-	<key>UILaunchStoryboardName</key>
-	<string>LaunchScreen</string>
+<key>LSRequiresIPhoneOS</key>
+<true/>
+<key>NSCameraUsageDescription</key>
+<string>Necesitamos acceder a la cámara para detectar objetos en tiempo real.</string>
+<key>UILaunchStoryboardName</key>
+<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
 	<key>UISupportedInterfaceOrientations</key>

--- a/lib/detection_page.dart
+++ b/lib/detection_page.dart
@@ -1,0 +1,670 @@
+import 'dart:async';
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:camera/camera.dart';
+import 'package:flutter/material.dart';
+import 'package:image/image.dart' as image_lib;
+import 'package:tflite_flutter/tflite_flutter.dart';
+import 'package:tflite_flutter_helper/tflite_flutter_helper.dart';
+
+class DetectionPage extends StatefulWidget {
+  const DetectionPage({super.key});
+
+  @override
+  State<DetectionPage> createState() => _DetectionPageState();
+}
+
+class _DetectionPageState extends State<DetectionPage>
+    with WidgetsBindingObserver {
+  static const int _inputSize = 640;
+  static const double _confidenceThreshold = 0.35;
+  static const double _nmsThreshold = 0.45;
+  static const double _assumedObjectHeightMeters = 1.7;
+  static const double _assumedFocalLengthPixels = 880;
+
+  final List<String> _labels = const [
+    'persona',
+    'bicicleta',
+    'auto',
+    'motocicleta',
+    'avión',
+    'autobús',
+    'tren',
+    'camión',
+    'barco',
+    'semaforo',
+    'hidrante',
+    'señal de pare',
+    'parquímetro',
+    'banca',
+    'ave',
+    'gato',
+    'perro',
+    'caballo',
+    'oveja',
+    'vaca',
+    'elefante',
+    'oso',
+    'cebra',
+    'jirafa',
+    'mochila',
+    'paraguas',
+    'bolso',
+    'corbata',
+    'maleta',
+    'frisbee',
+    'esquíes',
+    'snowboard',
+    'balón deportivo',
+    'cometa',
+    'bate de béisbol',
+    'guante de béisbol',
+    'patineta',
+    'tabla de surf',
+    'raqueta de tenis',
+    'botella',
+    'copa de vino',
+    'taza',
+    'tenedor',
+    'cuchillo',
+    'cuchara',
+    'tazón',
+    'plátano',
+    'manzana',
+    'sándwich',
+    'naranja',
+    'brócoli',
+    'zanahoria',
+    'hot dog',
+    'pizza',
+    'donut',
+    'pastel',
+    'silla',
+    'sofá',
+    'planta en maceta',
+    'cama',
+    'mesa',
+    'inodoro',
+    'televisor',
+    'laptop',
+    'ratón',
+    'control remoto',
+    'teclado',
+    'teléfono celular',
+    'microondas',
+    'horno',
+    'tostadora',
+    'lavamanos',
+    'refrigerador',
+    'libro',
+    'reloj',
+    'florero',
+    'tijeras',
+    'oso de peluche',
+    'secador de cabello',
+    'cepillo de dientes',
+  ];
+
+  CameraController? _cameraController;
+  Interpreter? _interpreter;
+  TensorImage? _inputImage;
+  ImageProcessor? _imageProcessor;
+  List<DetectionResult> _results = const [];
+  bool _isBusy = false;
+  bool _initializing = true;
+  String? _error;
+  Size _previewSize = Size.zero;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    _initialize();
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    _stopImageStream();
+    _cameraController?.dispose();
+    _interpreter?.close();
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (_cameraController == null || !_cameraController!.value.isInitialized) {
+      return;
+    }
+
+    if (state == AppLifecycleState.inactive || state == AppLifecycleState.paused) {
+      _stopImageStream();
+      _cameraController?.dispose();
+      _cameraController = null;
+    } else if (state == AppLifecycleState.resumed) {
+      _initializeCamera();
+    }
+  }
+
+  Future<void> _initialize() async {
+    try {
+      await _loadModel();
+      await _initializeCamera();
+      if (mounted) {
+        setState(() {
+          _initializing = false;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _error = 'No se pudo inicializar la detección: $e';
+          _initializing = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _loadModel() async {
+    final options = InterpreterOptions()..threads = 2;
+    _interpreter = await Interpreter.fromAsset('models/yolo11n.tflite', options: options);
+    _inputImage = TensorImage(TfLiteType.float32);
+    _imageProcessor = ImageProcessorBuilder()
+        .add(ResizeOp(_inputSize, _inputSize, ResizeMethod.bilinear))
+        .add(NormalizeOp(0, 255))
+        .build();
+  }
+
+  Future<void> _initializeCamera() async {
+    try {
+      await _cameraController?.dispose();
+
+      final cameras = await availableCameras();
+      if (cameras.isEmpty) {
+        throw Exception('No se encontró ninguna cámara disponible.');
+      }
+      final camera = cameras.firstWhere(
+        (c) => c.lensDirection == CameraLensDirection.back,
+        orElse: () => cameras.first,
+      );
+      final controller = CameraController(
+        camera,
+        ResolutionPreset.medium,
+        enableAudio: false,
+      );
+      await controller.initialize();
+      final previewSize = controller.value.previewSize;
+      if (previewSize != null) {
+        _previewSize = Size(previewSize.height, previewSize.width);
+      } else {
+        _previewSize = Size(_inputSize.toDouble(), _inputSize.toDouble());
+      }
+      await controller.startImageStream(_processCameraImage);
+      if (mounted) {
+        setState(() {
+          _cameraController = controller;
+        });
+      } else {
+        await controller.dispose();
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _error = 'Error al iniciar la cámara: $e';
+        });
+      }
+    }
+  }
+
+  Future<void> _stopImageStream() async {
+    if (_cameraController != null && _cameraController!.value.isStreamingImages) {
+      await _cameraController!.stopImageStream();
+    }
+  }
+
+  Future<void> _processCameraImage(CameraImage image) async {
+    if (_interpreter == null || _imageProcessor == null || _inputImage == null || _isBusy) {
+      return;
+    }
+    _isBusy = true;
+
+    try {
+      final imageLib = _convertYUV420ToImage(image);
+      final tensorImage = _inputImage!;
+      tensorImage.loadImage(image_lib.copyResize(imageLib, width: _inputSize, height: _inputSize));
+      final processedImage = _imageProcessor!.process(tensorImage);
+
+      final outputTensor = _interpreter!.getOutputTensor(0);
+      final outputBuffer = TensorBuffer.createFixedSize(outputTensor.shape, outputTensor.type);
+
+      _interpreter!.run(processedImage.buffer, outputBuffer.buffer);
+
+      final detections = _parseDetections(outputBuffer.getDoubleList(), outputTensor.shape);
+      if (mounted) {
+        setState(() {
+          _results = detections;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _error = 'Error al procesar imagen: $e';
+        });
+      }
+    } finally {
+      _isBusy = false;
+    }
+  }
+
+  List<DetectionResult> _parseDetections(List<double> outputs, List<int> outputShape) {
+    int numDetections;
+    int valuesPerDetection;
+    if (outputShape.length == 3) {
+      numDetections = outputShape[1];
+      valuesPerDetection = outputShape[2];
+    } else if (outputShape.length == 2) {
+      numDetections = outputShape[0];
+      valuesPerDetection = outputShape[1];
+    } else {
+      return const [];
+    }
+
+    final List<DetectionResult> parsedDetections = [];
+    for (int i = 0; i < numDetections; i++) {
+      final offset = i * valuesPerDetection;
+      if (offset + 5 >= outputs.length) {
+        break;
+      }
+
+      double x = outputs[offset];
+      double y = outputs[offset + 1];
+      double w = outputs[offset + 2];
+      double h = outputs[offset + 3];
+      final double objectConfidence = outputs[offset + 4];
+
+      if (objectConfidence < _confidenceThreshold) {
+        continue;
+      }
+
+      final classScores = outputs.sublist(offset + 5, offset + valuesPerDetection);
+      if (classScores.isEmpty) {
+        continue;
+      }
+
+      double maxScore = classScores.first;
+      int maxIndex = 0;
+      for (int j = 1; j < classScores.length; j++) {
+        if (classScores[j] > maxScore) {
+          maxScore = classScores[j];
+          maxIndex = j;
+        }
+      }
+
+      final double confidence = objectConfidence * maxScore;
+      if (confidence < _confidenceThreshold) {
+        continue;
+      }
+
+      final bool normalized = x <= 1.0 && y <= 1.0 && w <= 1.0 && h <= 1.0;
+      final double boxScale = normalized ? 1.0 : _inputSize.toDouble();
+
+      x *= boxScale;
+      y *= boxScale;
+      w *= boxScale;
+      h *= boxScale;
+
+      final double left = ((x - w / 2) / _inputSize).clamp(0.0, 1.0);
+      final double top = ((y - h / 2) / _inputSize).clamp(0.0, 1.0);
+      final double right = ((x + w / 2) / _inputSize).clamp(0.0, 1.0);
+      final double bottom = ((y + h / 2) / _inputSize).clamp(0.0, 1.0);
+
+      final rect = Rect.fromLTRB(left, top, right, bottom);
+      final distanceMeters = _estimateDistance(rect.height);
+      final label = maxIndex < _labels.length ? _labels[maxIndex] : 'objeto';
+
+      parsedDetections.add(DetectionResult(
+        boundingBox: rect,
+        label: label,
+        confidence: confidence,
+        distanceMeters: distanceMeters,
+      ));
+    }
+
+    return _nonMaxSuppression(parsedDetections, _nmsThreshold).take(10).toList();
+  }
+
+  double _estimateDistance(double normalizedHeight) {
+    if (normalizedHeight <= 0) {
+      return double.infinity;
+    }
+    final double pixelHeight = normalizedHeight * _inputSize;
+    final double distanceMeters =
+        (_assumedObjectHeightMeters * _assumedFocalLengthPixels) / (pixelHeight + 1e-6);
+    return distanceMeters.isFinite ? distanceMeters : double.infinity;
+  }
+
+  List<DetectionResult> _nonMaxSuppression(List<DetectionResult> detections, double iouThreshold) {
+    final List<DetectionResult> sortedDetections = List.of(detections)
+      ..sort((a, b) => b.confidence.compareTo(a.confidence));
+    final List<DetectionResult> kept = [];
+
+    for (final candidate in sortedDetections) {
+      bool shouldAdd = true;
+      for (final keptDetection in kept) {
+        if (_intersectionOverUnion(candidate.boundingBox, keptDetection.boundingBox) > iouThreshold) {
+          shouldAdd = false;
+          break;
+        }
+      }
+      if (shouldAdd) {
+        kept.add(candidate);
+      }
+    }
+    return kept;
+  }
+
+  double _intersectionOverUnion(Rect a, Rect b) {
+    final double intersectionWidth = math.max(0, math.min(a.right, b.right) - math.max(a.left, b.left));
+    final double intersectionHeight = math.max(0, math.min(a.bottom, b.bottom) - math.max(a.top, b.top));
+    final double intersectionArea = intersectionWidth * intersectionHeight;
+    if (intersectionArea <= 0) {
+      return 0;
+    }
+    final double areaA = a.width * a.height;
+    final double areaB = b.width * b.height;
+    final double unionArea = areaA + areaB - intersectionArea;
+    return unionArea <= 0 ? 0 : intersectionArea / unionArea;
+  }
+
+  image_lib.Image _convertYUV420ToImage(CameraImage image) {
+    final int width = image.width;
+    final int height = image.height;
+    final image_lib.Image img = image_lib.Image(width: width, height: height);
+    final Plane planeY = image.planes[0];
+    final Plane planeU = image.planes[1];
+    final Plane planeV = image.planes[2];
+
+    final Uint8List bytesY = planeY.bytes;
+    final Uint8List bytesU = planeU.bytes;
+    final Uint8List bytesV = planeV.bytes;
+
+    final int uvRowStride = planeU.bytesPerRow;
+    final int uvPixelStride = planeU.bytesPerPixel ?? 1;
+
+    for (int y = 0; y < height; y++) {
+      for (int x = 0; x < width; x++) {
+        final int uvIndex = (y ~/ 2) * uvRowStride + (x ~/ 2) * uvPixelStride;
+        final int index = y * width + x;
+
+        final int yp = bytesY[index];
+        final int up = bytesU[uvIndex];
+        final int vp = bytesV[uvIndex];
+
+        int r = (yp + (vp - 128) * 1436 / 1024).round();
+        int g = (yp - (vp - 128) * 731 / 1024 - (up - 128) * 354 / 1024).round();
+        int b = (yp + (up - 128) * 1814 / 1024).round();
+
+        r = r.clamp(0, 255);
+        g = g.clamp(0, 255);
+        b = b.clamp(0, 255);
+
+        img.setPixelRgba(x, y, r, g, b);
+      }
+    }
+
+    return img;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      appBar: AppBar(
+        title: const Text('Detección en vivo'),
+        backgroundColor: Colors.black,
+        foregroundColor: Colors.white,
+      ),
+      body: _buildBody(),
+    );
+  }
+
+  Widget _buildBody() {
+    if (_initializing) {
+      return const Center(
+        child: CircularProgressIndicator(),
+      );
+    }
+
+    if (_error != null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24.0),
+          child: Text(
+            _error!,
+            style: const TextStyle(color: Colors.white70),
+            textAlign: TextAlign.center,
+          ),
+        ),
+      );
+    }
+
+    if (_cameraController == null || !_cameraController!.value.isInitialized) {
+      return const Center(
+        child: Text(
+          'Inicializando cámara...',
+          style: TextStyle(color: Colors.white70),
+        ),
+      );
+    }
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final previewSize = _previewSize;
+        final double previewWidth =
+            previewSize.width == 0 ? _inputSize.toDouble() : previewSize.width;
+        final double previewHeight =
+            previewSize.height == 0 ? _inputSize.toDouble() : previewSize.height;
+
+        return Column(
+          children: [
+            Expanded(
+              child: Stack(
+                fit: StackFit.expand,
+                children: [
+                  FittedBox(
+                    fit: BoxFit.cover,
+                    child: SizedBox(
+                      width: previewWidth,
+                      height: previewHeight,
+                      child: CameraPreview(_cameraController!),
+                    ),
+                  ),
+                  Positioned.fill(
+                    child: CustomPaint(
+                      painter: _DetectionPainter(
+                        detections: _results,
+                      ),
+                    ),
+                  ),
+                  Positioned(
+                    left: 16,
+                    top: 16,
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                      decoration: BoxDecoration(
+                        color: Colors.black.withOpacity(0.5),
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: Text(
+                        '${_results.length} objetos detectados',
+                        style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Container(
+              width: double.infinity,
+              decoration: const BoxDecoration(
+                color: Color(0xFF111111),
+                border: Border(top: BorderSide(color: Colors.white12)),
+              ),
+              padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
+              child: _results.isEmpty
+                  ? const Text(
+                      'Apunta la cámara hacia un objeto para comenzar la detección.',
+                      style: TextStyle(color: Colors.white70),
+                    )
+                  : Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const Text(
+                          'Objetos detectados',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        const SizedBox(height: 12),
+                        ..._results.map((detection) {
+                          return Padding(
+                            padding: const EdgeInsets.symmetric(vertical: 6),
+                            child: Row(
+                              children: [
+                                Expanded(
+                                  child: Text(
+                                    _formatDetectionLabel(detection),
+                                    style: const TextStyle(color: Colors.white),
+                                  ),
+                                ),
+                                Text(
+                                  _formatDistance(detection.distanceMeters),
+                                  style: const TextStyle(color: Colors.lightBlueAccent, fontWeight: FontWeight.bold),
+                                ),
+                              ],
+                            ),
+                          );
+                        }),
+                      ],
+                    ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  String _formatDetectionLabel(DetectionResult detection) {
+    final confidence = (detection.confidence * 100).clamp(0, 100).toStringAsFixed(0);
+    return '${detection.label} ($confidence%)';
+  }
+
+  String _formatDistance(double distance) {
+    if (!distance.isFinite) {
+      return 'distancia desconocida';
+    }
+    if (distance > 20) {
+      return '>20 m';
+    }
+    if (distance >= 5) {
+      return '${distance.toStringAsFixed(0)} m';
+    }
+    return '${distance.toStringAsFixed(1)} m';
+  }
+}
+
+class DetectionResult {
+  final Rect boundingBox;
+  final String label;
+  final double confidence;
+  final double distanceMeters;
+
+  const DetectionResult({
+    required this.boundingBox,
+    required this.label,
+    required this.confidence,
+    required this.distanceMeters,
+  });
+}
+
+class _DetectionPainter extends CustomPainter {
+  _DetectionPainter({required this.detections});
+
+  final List<DetectionResult> detections;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final Paint boxPaint = Paint()
+      ..color = Colors.lightBlueAccent.withOpacity(0.8)
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 3;
+
+    final Paint fillPaint = Paint()
+      ..color = Colors.lightBlueAccent.withOpacity(0.15)
+      ..style = PaintingStyle.fill;
+
+    for (final detection in detections) {
+      final Rect rect = Rect.fromLTRB(
+        detection.boundingBox.left * size.width,
+        detection.boundingBox.top * size.height,
+        detection.boundingBox.right * size.width,
+        detection.boundingBox.bottom * size.height,
+      );
+
+      canvas.drawRect(rect, fillPaint);
+      canvas.drawRect(rect, boxPaint);
+
+      final textSpan = TextSpan(
+        text:
+            '${detection.label} ${(detection.confidence * 100).toStringAsFixed(0)}%\n${_formatDistance(detection.distanceMeters)}',
+        style: const TextStyle(
+          color: Colors.white,
+          fontSize: 14,
+          fontWeight: FontWeight.bold,
+        ),
+      );
+      final textPainter = TextPainter(
+        text: textSpan,
+        textDirection: TextDirection.ltr,
+        maxLines: 2,
+      )..layout(maxWidth: size.width * 0.6);
+
+      final labelOffset = Offset(rect.left, math.max(0, rect.top - textPainter.height - 4));
+      final backgroundRect = Rect.fromLTWH(
+        labelOffset.dx,
+        labelOffset.dy,
+        textPainter.width + 12,
+        textPainter.height + 8,
+      );
+      final backgroundPaint = Paint()
+        ..color = Colors.black.withOpacity(0.6)
+        ..style = PaintingStyle.fill;
+      canvas.drawRRect(
+        RRect.fromRectAndRadius(backgroundRect, const Radius.circular(8)),
+        backgroundPaint,
+      );
+      textPainter.paint(canvas, labelOffset + const Offset(6, 4));
+    }
+  }
+
+  String _formatDistance(double distance) {
+    if (!distance.isFinite) {
+      return 'dist. ?';
+    }
+    if (distance > 20) {
+      return '>20 m';
+    }
+    if (distance >= 5) {
+      return '${distance.toStringAsFixed(0)} m';
+    }
+    return '${distance.toStringAsFixed(1)} m';
+  }
+
+  @override
+  bool shouldRepaint(covariant _DetectionPainter oldDelegate) {
+    return oldDelegate.detections != detections;
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,8 @@ import 'package:intl/intl.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:speech_to_text/speech_to_text.dart' as stt;
 
+import 'detection_page.dart';
+
 void main() {
   runApp(const CellSayApp());
 }
@@ -416,6 +418,12 @@ class _HomePageState extends State<HomePage> {
     );
   }
 
+  Future<void> _abrirDeteccionObjetos() async {
+    await Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => const DetectionPage()),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
@@ -481,6 +489,10 @@ class _HomePageState extends State<HomePage> {
                         ? 'Reconocimiento de semáforos activado'
                         : 'Reconocimiento de semáforos desactivado');
                   },
+                ),
+                const SizedBox(height: 12),
+                _DetectionFeatureCard(
+                  onOpen: _abrirDeteccionObjetos,
                 ),
                 const SizedBox(height: 12),
                 _DangerCard(
@@ -636,6 +648,59 @@ class _StatusCard extends StatelessWidget {
           Text(
             description,
             style: Theme.of(context).textTheme.bodySmall?.copyWith(color: Colors.white70),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DetectionFeatureCard extends StatelessWidget {
+  final VoidCallback onOpen;
+
+  const _DetectionFeatureCard({required this.onOpen});
+
+  @override
+  Widget build(BuildContext context) {
+    return _BaseCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(Icons.camera_alt, color: Colors.white),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  'Detección con cámara en vivo',
+                  style: Theme.of(context)
+                      .textTheme
+                      .titleMedium
+                      ?.copyWith(color: Colors.white, fontWeight: FontWeight.bold),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Abre la cámara para detectar objetos en tiempo real con YOLO11n y recibir una estimación de distancia.',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(color: Colors.white70),
+          ),
+          const SizedBox(height: 12),
+          ElevatedButton.icon(
+            onPressed: onOpen,
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Colors.blueAccent,
+              foregroundColor: Colors.white,
+              padding: const EdgeInsets.symmetric(vertical: 16),
+            ),
+            icon: const Icon(Icons.play_arrow),
+            label: const Text('Abrir cámara de detección'),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Las distancias son aproximadas y dependen del tamaño del objeto en pantalla.',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(color: Colors.white54),
           ),
         ],
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,10 @@ dependencies:
   intl: ^0.20.2
   flutter_tts: ^4.2.3
   speech_to_text: ^7.0.0
+  camera: ^0.10.5+9
+  tflite_flutter: ^0.10.2
+  tflite_flutter_helper: ^0.3.4
+  image: ^4.1.7
 
 dev_dependencies:
   flutter_test:
@@ -23,3 +27,5 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+  assets:
+    - assets/models/yolo11n.tflite


### PR DESCRIPTION
## Summary
- add a dedicated detection page that streams camera frames through the YOLO11n TensorFlow Lite model and renders bounding boxes with distance estimates
- expose the live detection workflow from the home screen and package the model under assets with the required runtime dependencies
- request camera permissions on Android and iOS so the feature can access the device camera

## Testing
- not run (Flutter SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68de0f61225c832eb6a1ded488e75f59