### PR TITLE
Remove tflite_flutter_helper and implement manual preprocessing

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,6 @@ dependencies:
   speech_to_text: ^7.0.0
   camera: ^0.10.5+9
   tflite_flutter: ^0.10.2
-  tflite_flutter_helper: ^0.3.4
   image: ^4.1.7
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- drop the tflite_flutter_helper dependency that is not compatible with the current Dart SDK
- replace the helper-based preprocessing with manual resizing, normalization, and tensor buffer handling so the interpreter can still run

## Testing
- flutter pub get *(fails: Flutter is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68de14f33ef0832e8836eb24c8be8ba9